### PR TITLE
simplify bootstrap profiles to only point at single upstream project; this will ensure no duplicate GAVs when building the whole stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<profile>
 			<id>bootstrap</id>
 			<modules>
-				<module>../base</module>
+				<module>../hibernate</module>
 			</modules>
 		</profile>
 	</profiles>


### PR DESCRIPTION
...is will ensure no duplicate GAVs when building the whole stack
