### PR TITLE
JBIDE-15238 - Bump parent pom version in root pom to 4.1.0.Final-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.CR1-SNAPSHOT</version>
+		<version>4.1.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>birt</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-15238
For JBIDE 4.1.0.Final: Bump parent pom version in root pom to 4.1.0.Final-SNAPSHOT [Birt]
