### PR TITLE
JBIDE-11436 - Migrate to use of o.j.t.foundation.license feature

### DIFF
--- a/features/org.jboss.tools.birt.feature/feature.properties
+++ b/features/org.jboss.tools.birt.feature/feature.properties
@@ -34,20 +34,3 @@ which accompanies this distribution, and is available at\n\
 http\://www.eclipse.org/legal/epl-v10.html\n\n\
 Contributors\:\nJBoss by Red Hat - Initial implementation.
  ############### end of copyright property ####################################
-
-# "licenseURL" property - URL of the "Feature License"
-# do not translate value - just change to point to a locale-specific HTML page
-licenseURL=license.html
-
-# START NON-TRANSLATABLE
-# "license" property - text of the "Feature Update License"
-# should be plain text version of license agreement pointed to be "licenseURL"
-license=Red Hat, Inc. licenses these features and plugins to you under \
-certain open source licenses (or aggregations of such licenses), which \
-in a particular case may include the Eclipse Public License, the GNU \
-Lesser General Public License, and/or certain other open source \
-licenses. For precise licensing details, consult the corresponding \
-source code, or contact Red Hat Legal Affairs, 1801 Varsity Drive, \
-Raleigh NC 27606 USA.
-# END NON-TRANSLATABLE
-########### end of license property ##########################################

--- a/features/org.jboss.tools.birt.feature/feature.xml
+++ b/features/org.jboss.tools.birt.feature/feature.xml
@@ -4,6 +4,8 @@
       label="%featureName"
       version="1.8.0.qualifier"
       provider-name="%providerName"
+      license-feature="org.jboss.tools.foundation.license.feature"
+      license-feature-version="0.0.0"
       plugin="org.jboss.tools.birt.oda.ui">
 
    <description>
@@ -14,7 +16,7 @@
       %copyright
    </copyright>
 
-   <license url="%licenseURL">
+   <license>
       %license
    </license>
 

--- a/features/org.jboss.tools.birt.feature/feature_ja.properties
+++ b/features/org.jboss.tools.birt.feature/feature_ja.properties
@@ -5,4 +5,3 @@ birtUpdateSiteName=Business Intelligence and Reporting Tools (BIRT) Updates
 description=JBoss BIRT \u9023\u643A
 copyright=Copyright (c) 2008-2014 JBoss by Red Hat and others.\nAll rights reserved. This program and the accompanying materials\n 
 are=made available under the terms of the Eclipse Public License v1.0which accompanies this distribution, and is available athttp//www.eclipse.org/legal/epl-v10.htmlContributorsJBoss by Red Hat - Initial implementation.
-licenseURL=license.html

--- a/features/org.jboss.tools.birt.test.feature/feature.properties
+++ b/features/org.jboss.tools.birt.test.feature/feature.properties
@@ -35,20 +35,3 @@ http\://www.eclipse.org/legal/epl-v10.html\n\
 Contributors\:\n\
 JBoss by Red Hat - Initial implementation.\n
  ############### end of copyright property ####################################
-
-# "licenseURL" property - URL of the "Feature License"
-# do not translate value - just change to point to a locale-specific HTML page
-licenseURL=license.html
-
-# START NON-TRANSLATABLE
-# "license" property - text of the "Feature Update License"
-# should be plain text version of license agreement pointed to be "licenseURL"
-license=Red Hat, Inc. licenses these features and plugins to you under \
-certain open source licenses (or aggregations of such licenses), which \
-in a particular case may include the Eclipse Public License, the GNU \
-Lesser General Public License, and/or certain other open source \
-licenses. For precise licensing details, consult the corresponding \
-source code, or contact Red Hat Legal Affairs, 1801 Varsity Drive, \
-Raleigh NC 27606 USA.
-# END NON-TRANSLATABLE
-########### end of license property ##########################################

--- a/features/org.jboss.tools.birt.test.feature/feature.xml
+++ b/features/org.jboss.tools.birt.test.feature/feature.xml
@@ -4,6 +4,8 @@
       label="%featureName"
       version="1.8.0.qualifier"
       provider-name="%providerName"
+      license-feature="org.jboss.tools.foundation.license.feature"
+      license-feature-version="0.0.0"
       plugin="org.jboss.tools.birt.core.test">
 
    <description>
@@ -14,7 +16,7 @@
       %copyright
    </copyright>
 
-   <license url="%licenseURL">
+   <license>
       %license
    </license>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-11436
Migrate to use of o.j.t.foundation.license feature