### PR TITLE
JBIDE-20208 - Updating component version to 1.8.0-SNAPSHOT

### DIFF
--- a/features/org.jboss.tools.birt.feature/feature.xml
+++ b/features/org.jboss.tools.birt.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.birt.feature"
       label="%featureName"
-      version="1.9.0.qualifier"
+      version="1.8.0.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/features/org.jboss.tools.birt.feature/pom.xml
+++ b/features/org.jboss.tools.birt.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.birt</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt.features</groupId>
 	<artifactId>org.jboss.tools.birt.feature</artifactId> 

--- a/features/org.jboss.tools.birt.test.feature/feature.xml
+++ b/features/org.jboss.tools.birt.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.birt.test.feature"
       label="%featureName"
-      version="1.9.0.qualifier"
+      version="1.8.0.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/features/org.jboss.tools.birt.test.feature/pom.xml
+++ b/features/org.jboss.tools.birt.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.birt</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt.features</groupId>
 	<artifactId>org.jboss.tools.birt.test.feature</artifactId> 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>birt</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.birt.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.birt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.birt.core;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.8.0.qualifier
 Bundle-Activator: org.jboss.tools.birt.core.BirtCoreActivator
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.birt.core/pom.xml
+++ b/plugins/org.jboss.tools.birt.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.birt</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt.plugins</groupId>
 	<artifactId>org.jboss.tools.birt.core</artifactId> 

--- a/plugins/org.jboss.tools.birt.oda.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.birt.oda.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.birt.oda.ui;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.8.0.qualifier
 Bundle-Activator: org.jboss.tools.birt.oda.ui.Activator
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.birt.oda.ui/pom.xml
+++ b/plugins/org.jboss.tools.birt.oda.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.birt</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt.plugins</groupId>
 	<artifactId>org.jboss.tools.birt.oda.ui</artifactId> 

--- a/plugins/org.jboss.tools.birt.oda/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.birt.oda/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.jboss.tools.birt.oda;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.8.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.jboss.tools.birt.oda.Activator
 Bundle-Vendor: %BundleVendor

--- a/plugins/org.jboss.tools.birt.oda/pom.xml
+++ b/plugins/org.jboss.tools.birt.oda/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.birt</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt.plugins</groupId>
 	<artifactId>org.jboss.tools.birt.oda</artifactId> 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>birt</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>birt</artifactId>
 	<name>jbosstools-birt</name>
-	<version>1.9.0-SNAPSHOT</version>
+	<version>1.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
  		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-birt.git</tycho.scmUrl>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>birt</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt</groupId>
 	<artifactId>birt.site</artifactId>

--- a/tests/org.jboss.tools.birt.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.birt.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BIRT Core Tests
 Bundle-SymbolicName: org.jboss.tools.birt.core.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.8.0.qualifier
 Bundle-Vendor: JBoss by RedHat
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.jboss.tools.tests,

--- a/tests/org.jboss.tools.birt.core.test/pom.xml
+++ b/tests/org.jboss.tools.birt.core.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.birt</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt.tests</groupId>
 	<artifactId>org.jboss.tools.birt.core.test</artifactId> 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>birt</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.birt</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-20208
"For JBIDE 4.3.0.CR1: Migrate to using license feature in JBT 4.3 / JBDS 9 [Birt]